### PR TITLE
Display data for intro form's current monitor. Bugfixes.

### DIFF
--- a/Pixel Density/FormDensity.cs
+++ b/Pixel Density/FormDensity.cs
@@ -15,13 +15,12 @@ namespace Pixel_Density
 
         private void FormDensity_Load(object sender, EventArgs e)
         {
-            this.Size = new Size(1000, 1000);
+            this.WindowState = FormWindowState.Maximized;
             this.Location = new Point(0, 0);
         }
 
         private void Panel_Paint(object sender, PaintEventArgs e)
         {
-
             using (var blackPen = new Pen(Color.FromArgb(255, 0, 0, 0)))
             using (var whitePen = new Pen(Color.FromArgb(255, 255, 255, 255)))
             {
@@ -43,9 +42,6 @@ namespace Pixel_Density
 
             Rectangle screenRectangle = RectangleToScreen(this.ClientRectangle);
 
-            var topMargin = screenRectangle.Top - this.Top;
-            var leftMargin = screenRectangle.Left - this.Left;
-
             var leftSide = 0;
             var columnCounter = 0;
             var rowCounter = 0;
@@ -53,7 +49,7 @@ namespace Pixel_Density
 
             while (leftSide <= this.Width && rowCounter <= rowsRequired)
             {
-                e.Graphics.CopyFromScreen(leftMargin, topMargin, DRAWN_SQUARE_SIZE * columnCounter, DRAWN_SQUARE_SIZE * rowCounter, new Size(DRAWN_SQUARE_SIZE, DRAWN_SQUARE_SIZE));
+                e.Graphics.CopyFromScreen(screenRectangle.Left, screenRectangle.Top, DRAWN_SQUARE_SIZE * columnCounter, DRAWN_SQUARE_SIZE * rowCounter, new Size(DRAWN_SQUARE_SIZE, DRAWN_SQUARE_SIZE));
                 leftSide += DRAWN_SQUARE_SIZE;
                 columnCounter++;
                 if (leftSide >= this.Width)

--- a/Pixel Density/FormDensity.cs
+++ b/Pixel Density/FormDensity.cs
@@ -8,15 +8,15 @@ namespace Pixel_Density
     {
         private const int DRAWN_SQUARE_SIZE = 50;
 
-        public FormDensity()
+        public FormDensity(int startX = 0, int startY = 0)
         {
             InitializeComponent();
+            this.Location = new Point(startX, startY);
         }
 
         private void FormDensity_Load(object sender, EventArgs e)
         {
             this.WindowState = FormWindowState.Maximized;
-            this.Location = new Point(0, 0);
         }
 
         private void Panel_Paint(object sender, PaintEventArgs e)

--- a/Pixel Density/FormIntro.Designer.cs
+++ b/Pixel Density/FormIntro.Designer.cs
@@ -31,7 +31,14 @@
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(FormIntro));
             this.lblIntro = new System.Windows.Forms.Label();
             this.btnLoadGridForm = new System.Windows.Forms.Button();
-            this.lblPPI = new System.Windows.Forms.Label();
+            this.grpMoniInfo = new System.Windows.Forms.GroupBox();
+            this.lblMoniWidth = new System.Windows.Forms.Label();
+            this.lblMoniHeight = new System.Windows.Forms.Label();
+            this.lblMoniPPI = new System.Windows.Forms.Label();
+            this.lblMoniResX = new System.Windows.Forms.Label();
+            this.lblMoniResY = new System.Windows.Forms.Label();
+            this.lblMoniDiagonal = new System.Windows.Forms.Label();
+            this.grpMoniInfo.SuspendLayout();
             this.SuspendLayout();
             // 
             // lblIntro
@@ -39,7 +46,7 @@
             this.lblIntro.Font = new System.Drawing.Font("Microsoft Sans Serif", 15.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.lblIntro.Location = new System.Drawing.Point(12, 9);
             this.lblIntro.Name = "lblIntro";
-            this.lblIntro.Size = new System.Drawing.Size(776, 487);
+            this.lblIntro.Size = new System.Drawing.Size(776, 507);
             this.lblIntro.TabIndex = 0;
             this.lblIntro.Text = resources.GetString("lblIntro.Text");
             // 
@@ -47,7 +54,7 @@
             // 
             this.btnLoadGridForm.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.btnLoadGridForm.Font = new System.Drawing.Font("Microsoft Sans Serif", 15.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.btnLoadGridForm.Location = new System.Drawing.Point(17, 498);
+            this.btnLoadGridForm.Location = new System.Drawing.Point(12, 520);
             this.btnLoadGridForm.Name = "btnLoadGridForm";
             this.btnLoadGridForm.Size = new System.Drawing.Size(771, 36);
             this.btnLoadGridForm.TabIndex = 1;
@@ -55,23 +62,88 @@
             this.btnLoadGridForm.UseVisualStyleBackColor = true;
             this.btnLoadGridForm.Click += new System.EventHandler(this.btnLoadGridForm_Click);
             // 
-            // lblPPI
+            // grpMoniInfo
             // 
-            this.lblPPI.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.lblPPI.AutoSize = true;
-            this.lblPPI.Font = new System.Drawing.Font("Microsoft Sans Serif", 15.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lblPPI.Location = new System.Drawing.Point(12, 538);
-            this.lblPPI.Name = "lblPPI";
-            this.lblPPI.Size = new System.Drawing.Size(270, 25);
-            this.lblPPI.TabIndex = 2;
-            this.lblPPI.Text = "Current Monitor\'s PPI: {ppi}";
+            this.grpMoniInfo.Controls.Add(this.lblMoniDiagonal);
+            this.grpMoniInfo.Controls.Add(this.lblMoniResY);
+            this.grpMoniInfo.Controls.Add(this.lblMoniResX);
+            this.grpMoniInfo.Controls.Add(this.lblMoniPPI);
+            this.grpMoniInfo.Controls.Add(this.lblMoniHeight);
+            this.grpMoniInfo.Controls.Add(this.lblMoniWidth);
+            this.grpMoniInfo.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, ((System.Drawing.FontStyle)((System.Drawing.FontStyle.Bold | System.Drawing.FontStyle.Underline))), System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.grpMoniInfo.Location = new System.Drawing.Point(794, 12);
+            this.grpMoniInfo.Name = "grpMoniInfo";
+            this.grpMoniInfo.Size = new System.Drawing.Size(261, 152);
+            this.grpMoniInfo.TabIndex = 3;
+            this.grpMoniInfo.TabStop = false;
+            this.grpMoniInfo.Text = "Current Monitor Information";
+            // 
+            // lblMoniWidth
+            // 
+            this.lblMoniWidth.AutoSize = true;
+            this.lblMoniWidth.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lblMoniWidth.Location = new System.Drawing.Point(6, 22);
+            this.lblMoniWidth.Name = "lblMoniWidth";
+            this.lblMoniWidth.Size = new System.Drawing.Size(161, 20);
+            this.lblMoniWidth.TabIndex = 0;
+            this.lblMoniWidth.Text = "Physical Width (in):";
+            // 
+            // lblMoniHeight
+            // 
+            this.lblMoniHeight.AutoSize = true;
+            this.lblMoniHeight.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lblMoniHeight.Location = new System.Drawing.Point(6, 42);
+            this.lblMoniHeight.Name = "lblMoniHeight";
+            this.lblMoniHeight.Size = new System.Drawing.Size(168, 20);
+            this.lblMoniHeight.TabIndex = 1;
+            this.lblMoniHeight.Text = "Physical Height (in):";
+            // 
+            // lblMoniPPI
+            // 
+            this.lblMoniPPI.AutoSize = true;
+            this.lblMoniPPI.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lblMoniPPI.Location = new System.Drawing.Point(6, 122);
+            this.lblMoniPPI.Name = "lblMoniPPI";
+            this.lblMoniPPI.Size = new System.Drawing.Size(156, 20);
+            this.lblMoniPPI.TabIndex = 2;
+            this.lblMoniPPI.Text = "Density (ppi): {ppi}";
+            // 
+            // lblMoniResX
+            // 
+            this.lblMoniResX.AutoSize = true;
+            this.lblMoniResX.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lblMoniResX.Location = new System.Drawing.Point(6, 82);
+            this.lblMoniResX.Name = "lblMoniResX";
+            this.lblMoniResX.Size = new System.Drawing.Size(240, 20);
+            this.lblMoniResX.TabIndex = 3;
+            this.lblMoniResX.Text = "Resolution Width (px): {resX}";
+            // 
+            // lblMoniResY
+            // 
+            this.lblMoniResY.AutoSize = true;
+            this.lblMoniResY.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lblMoniResY.Location = new System.Drawing.Point(6, 102);
+            this.lblMoniResY.Name = "lblMoniResY";
+            this.lblMoniResY.Size = new System.Drawing.Size(247, 20);
+            this.lblMoniResY.TabIndex = 3;
+            this.lblMoniResY.Text = "Resolution Height (px): {resY}";
+            // 
+            // lblMoniDiagonal
+            // 
+            this.lblMoniDiagonal.AutoSize = true;
+            this.lblMoniDiagonal.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lblMoniDiagonal.Location = new System.Drawing.Point(6, 62);
+            this.lblMoniDiagonal.Name = "lblMoniDiagonal";
+            this.lblMoniDiagonal.Size = new System.Drawing.Size(186, 20);
+            this.lblMoniDiagonal.TabIndex = 4;
+            this.lblMoniDiagonal.Text = "Physical Diagonal (in):";
             // 
             // FormIntro
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(807, 571);
-            this.Controls.Add(this.lblPPI);
+            this.ClientSize = new System.Drawing.Size(1071, 568);
+            this.Controls.Add(this.grpMoniInfo);
             this.Controls.Add(this.btnLoadGridForm);
             this.Controls.Add(this.lblIntro);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
@@ -81,8 +153,9 @@
             this.Text = "Pixel Density Intro";
             this.Load += new System.EventHandler(this.FormIntro_Load);
             this.Move += new System.EventHandler(this.FormIntro_Move);
+            this.grpMoniInfo.ResumeLayout(false);
+            this.grpMoniInfo.PerformLayout();
             this.ResumeLayout(false);
-            this.PerformLayout();
 
         }
 
@@ -90,7 +163,13 @@
 
         private System.Windows.Forms.Label lblIntro;
         private System.Windows.Forms.Button btnLoadGridForm;
-        private System.Windows.Forms.Label lblPPI;
+        private System.Windows.Forms.GroupBox grpMoniInfo;
+        private System.Windows.Forms.Label lblMoniHeight;
+        private System.Windows.Forms.Label lblMoniWidth;
+        private System.Windows.Forms.Label lblMoniPPI;
+        private System.Windows.Forms.Label lblMoniResY;
+        private System.Windows.Forms.Label lblMoniResX;
+        private System.Windows.Forms.Label lblMoniDiagonal;
     }
 }
 

--- a/Pixel Density/FormIntro.Designer.cs
+++ b/Pixel Density/FormIntro.Designer.cs
@@ -32,12 +32,12 @@
             this.lblIntro = new System.Windows.Forms.Label();
             this.btnLoadGridForm = new System.Windows.Forms.Button();
             this.grpMoniInfo = new System.Windows.Forms.GroupBox();
-            this.lblMoniWidth = new System.Windows.Forms.Label();
-            this.lblMoniHeight = new System.Windows.Forms.Label();
-            this.lblMoniPPI = new System.Windows.Forms.Label();
-            this.lblMoniResX = new System.Windows.Forms.Label();
-            this.lblMoniResY = new System.Windows.Forms.Label();
             this.lblMoniDiagonal = new System.Windows.Forms.Label();
+            this.lblMoniResY = new System.Windows.Forms.Label();
+            this.lblMoniResX = new System.Windows.Forms.Label();
+            this.lblMoniPPI = new System.Windows.Forms.Label();
+            this.lblMoniHeight = new System.Windows.Forms.Label();
+            this.lblMoniWidth = new System.Windows.Forms.Label();
             this.grpMoniInfo.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -78,45 +78,15 @@
             this.grpMoniInfo.TabStop = false;
             this.grpMoniInfo.Text = "Current Monitor Information";
             // 
-            // lblMoniWidth
+            // lblMoniDiagonal
             // 
-            this.lblMoniWidth.AutoSize = true;
-            this.lblMoniWidth.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lblMoniWidth.Location = new System.Drawing.Point(6, 22);
-            this.lblMoniWidth.Name = "lblMoniWidth";
-            this.lblMoniWidth.Size = new System.Drawing.Size(161, 20);
-            this.lblMoniWidth.TabIndex = 0;
-            this.lblMoniWidth.Text = "Physical Width (in):";
-            // 
-            // lblMoniHeight
-            // 
-            this.lblMoniHeight.AutoSize = true;
-            this.lblMoniHeight.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lblMoniHeight.Location = new System.Drawing.Point(6, 42);
-            this.lblMoniHeight.Name = "lblMoniHeight";
-            this.lblMoniHeight.Size = new System.Drawing.Size(168, 20);
-            this.lblMoniHeight.TabIndex = 1;
-            this.lblMoniHeight.Text = "Physical Height (in):";
-            // 
-            // lblMoniPPI
-            // 
-            this.lblMoniPPI.AutoSize = true;
-            this.lblMoniPPI.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lblMoniPPI.Location = new System.Drawing.Point(6, 122);
-            this.lblMoniPPI.Name = "lblMoniPPI";
-            this.lblMoniPPI.Size = new System.Drawing.Size(156, 20);
-            this.lblMoniPPI.TabIndex = 2;
-            this.lblMoniPPI.Text = "Density (ppi): {ppi}";
-            // 
-            // lblMoniResX
-            // 
-            this.lblMoniResX.AutoSize = true;
-            this.lblMoniResX.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lblMoniResX.Location = new System.Drawing.Point(6, 82);
-            this.lblMoniResX.Name = "lblMoniResX";
-            this.lblMoniResX.Size = new System.Drawing.Size(240, 20);
-            this.lblMoniResX.TabIndex = 3;
-            this.lblMoniResX.Text = "Resolution Width (px): {resX}";
+            this.lblMoniDiagonal.AutoSize = true;
+            this.lblMoniDiagonal.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lblMoniDiagonal.Location = new System.Drawing.Point(6, 62);
+            this.lblMoniDiagonal.Name = "lblMoniDiagonal";
+            this.lblMoniDiagonal.Size = new System.Drawing.Size(186, 20);
+            this.lblMoniDiagonal.TabIndex = 4;
+            this.lblMoniDiagonal.Text = "Physical Diagonal (in):";
             // 
             // lblMoniResY
             // 
@@ -128,15 +98,45 @@
             this.lblMoniResY.TabIndex = 3;
             this.lblMoniResY.Text = "Resolution Height (px): {resY}";
             // 
-            // lblMoniDiagonal
+            // lblMoniResX
             // 
-            this.lblMoniDiagonal.AutoSize = true;
-            this.lblMoniDiagonal.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lblMoniDiagonal.Location = new System.Drawing.Point(6, 62);
-            this.lblMoniDiagonal.Name = "lblMoniDiagonal";
-            this.lblMoniDiagonal.Size = new System.Drawing.Size(186, 20);
-            this.lblMoniDiagonal.TabIndex = 4;
-            this.lblMoniDiagonal.Text = "Physical Diagonal (in):";
+            this.lblMoniResX.AutoSize = true;
+            this.lblMoniResX.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lblMoniResX.Location = new System.Drawing.Point(6, 82);
+            this.lblMoniResX.Name = "lblMoniResX";
+            this.lblMoniResX.Size = new System.Drawing.Size(240, 20);
+            this.lblMoniResX.TabIndex = 3;
+            this.lblMoniResX.Text = "Resolution Width (px): {resX}";
+            // 
+            // lblMoniPPI
+            // 
+            this.lblMoniPPI.AutoSize = true;
+            this.lblMoniPPI.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lblMoniPPI.Location = new System.Drawing.Point(6, 122);
+            this.lblMoniPPI.Name = "lblMoniPPI";
+            this.lblMoniPPI.Size = new System.Drawing.Size(156, 20);
+            this.lblMoniPPI.TabIndex = 2;
+            this.lblMoniPPI.Text = "Density (ppi): {ppi}";
+            // 
+            // lblMoniHeight
+            // 
+            this.lblMoniHeight.AutoSize = true;
+            this.lblMoniHeight.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lblMoniHeight.Location = new System.Drawing.Point(6, 42);
+            this.lblMoniHeight.Name = "lblMoniHeight";
+            this.lblMoniHeight.Size = new System.Drawing.Size(168, 20);
+            this.lblMoniHeight.TabIndex = 1;
+            this.lblMoniHeight.Text = "Physical Height (in):";
+            // 
+            // lblMoniWidth
+            // 
+            this.lblMoniWidth.AutoSize = true;
+            this.lblMoniWidth.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lblMoniWidth.Location = new System.Drawing.Point(6, 22);
+            this.lblMoniWidth.Name = "lblMoniWidth";
+            this.lblMoniWidth.Size = new System.Drawing.Size(161, 20);
+            this.lblMoniWidth.TabIndex = 0;
+            this.lblMoniWidth.Text = "Physical Width (in):";
             // 
             // FormIntro
             // 
@@ -152,7 +152,7 @@
             this.Name = "FormIntro";
             this.Text = "Pixel Density Intro";
             this.Load += new System.EventHandler(this.FormIntro_Load);
-            this.Move += new System.EventHandler(this.FormIntro_Move);
+            this.Move += new System.EventHandler(this.DisplayMonitorInfo);
             this.grpMoniInfo.ResumeLayout(false);
             this.grpMoniInfo.PerformLayout();
             this.ResumeLayout(false);

--- a/Pixel Density/FormIntro.Designer.cs
+++ b/Pixel Density/FormIntro.Designer.cs
@@ -29,18 +29,19 @@
         private void InitializeComponent()
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(FormIntro));
-            this.label1 = new System.Windows.Forms.Label();
+            this.lblIntro = new System.Windows.Forms.Label();
             this.btnLoadGridForm = new System.Windows.Forms.Button();
+            this.lblPPI = new System.Windows.Forms.Label();
             this.SuspendLayout();
             // 
-            // label1
+            // lblIntro
             // 
-            this.label1.Font = new System.Drawing.Font("Microsoft Sans Serif", 15.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label1.Location = new System.Drawing.Point(12, 9);
-            this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(776, 487);
-            this.label1.TabIndex = 0;
-            this.label1.Text = resources.GetString("label1.Text");
+            this.lblIntro.Font = new System.Drawing.Font("Microsoft Sans Serif", 15.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lblIntro.Location = new System.Drawing.Point(12, 9);
+            this.lblIntro.Name = "lblIntro";
+            this.lblIntro.Size = new System.Drawing.Size(776, 487);
+            this.lblIntro.TabIndex = 0;
+            this.lblIntro.Text = resources.GetString("lblIntro.Text");
             // 
             // btnLoadGridForm
             // 
@@ -48,33 +49,48 @@
             this.btnLoadGridForm.Font = new System.Drawing.Font("Microsoft Sans Serif", 15.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.btnLoadGridForm.Location = new System.Drawing.Point(17, 498);
             this.btnLoadGridForm.Name = "btnLoadGridForm";
-            this.btnLoadGridForm.Size = new System.Drawing.Size(776, 36);
+            this.btnLoadGridForm.Size = new System.Drawing.Size(771, 36);
             this.btnLoadGridForm.TabIndex = 1;
             this.btnLoadGridForm.Text = "DRAW THEM SQUAREZZZZ";
             this.btnLoadGridForm.UseVisualStyleBackColor = true;
             this.btnLoadGridForm.Click += new System.EventHandler(this.btnLoadGridForm_Click);
             // 
+            // lblPPI
+            // 
+            this.lblPPI.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.lblPPI.AutoSize = true;
+            this.lblPPI.Font = new System.Drawing.Font("Microsoft Sans Serif", 15.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lblPPI.Location = new System.Drawing.Point(12, 538);
+            this.lblPPI.Name = "lblPPI";
+            this.lblPPI.Size = new System.Drawing.Size(270, 25);
+            this.lblPPI.TabIndex = 2;
+            this.lblPPI.Text = "Current Monitor\'s PPI: {ppi}";
+            // 
             // FormIntro
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(811, 544);
+            this.ClientSize = new System.Drawing.Size(807, 571);
+            this.Controls.Add(this.lblPPI);
             this.Controls.Add(this.btnLoadGridForm);
-            this.Controls.Add(this.label1);
+            this.Controls.Add(this.lblIntro);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.Name = "FormIntro";
             this.Text = "Pixel Density Intro";
             this.Load += new System.EventHandler(this.FormIntro_Load);
+            this.Move += new System.EventHandler(this.FormIntro_Move);
             this.ResumeLayout(false);
+            this.PerformLayout();
 
         }
 
         #endregion
 
-        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.Label lblIntro;
         private System.Windows.Forms.Button btnLoadGridForm;
+        private System.Windows.Forms.Label lblPPI;
     }
 }
 

--- a/Pixel Density/FormIntro.cs
+++ b/Pixel Density/FormIntro.cs
@@ -1,11 +1,32 @@
-﻿using System;
+﻿using Microsoft.Win32;
+using System;
 using System.Drawing;
+using System.Runtime.InteropServices;
 using System.Windows.Forms;
 
 namespace Pixel_Density
 {
     public partial class FormIntro : Form
     {
+        [DllImport("gdi32.dll")]
+        static extern int GetDeviceCaps(IntPtr hdc, int nIndex);
+
+        private int _previousScreenIndex;
+        private int _currentScreenIndex;
+
+        private bool ScreenChanged()
+        {
+            _currentScreenIndex = Array.IndexOf(Screen.AllScreens, Screen.FromControl(this));
+
+            if (_currentScreenIndex != _previousScreenIndex)
+            {
+                _previousScreenIndex = _currentScreenIndex;
+                return true;
+            }
+
+            return false;
+        }
+
         public FormIntro()
         {
             InitializeComponent();
@@ -16,9 +37,50 @@ namespace Pixel_Density
             new FormDensity().Show();
         }
 
+        public void SystemEvents_DisplaySettingsChanged(object sender, EventArgs e)
+        {
+            CalculatePPI();
+        }
+
         private void FormIntro_Load(object sender, EventArgs e)
         {
             this.Location = new Point(0, 0);
+            SystemEvents.DisplaySettingsChanged += new EventHandler(SystemEvents_DisplaySettingsChanged);
+            CalculatePPI();
+        }
+
+        private void FormIntro_Move(object sender, EventArgs e)
+        {
+            if (ScreenChanged())
+            {
+                CalculatePPI();
+            }
+        }
+
+        private void CalculatePPI()
+        {
+            const int HORZSIZE = 4;
+            const int VERTSIZE = 6;
+            const double MM_TO_INCH_CONVERSION_FACTOR = 25.4;
+
+            Console.WriteLine($"DeviceName = {Screen.FromHandle(this.Handle).DeviceName}");
+            var hDC = Graphics.FromHwnd(this.Handle).GetHdc();
+            var horizontalSizeInMilliMeters = GetDeviceCaps(hDC, HORZSIZE);
+            var verticalSizeInMilliMeters = GetDeviceCaps(hDC, VERTSIZE);
+
+            var horizontalSizeInInches = horizontalSizeInMilliMeters / MM_TO_INCH_CONVERSION_FACTOR;
+            var verticalSizeInInches = verticalSizeInMilliMeters / MM_TO_INCH_CONVERSION_FACTOR;
+            var diagonalSizeInInches = Math.Sqrt(Math.Pow(horizontalSizeInInches, 2) + Math.Pow(verticalSizeInInches, 2));
+
+            var screenHeight = Screen.FromControl(this).Bounds.Height;
+            var screenWidth = Screen.FromControl(this).Bounds.Width;
+
+            Console.WriteLine($"screenHeight = {screenHeight}. screenWidth = {screenWidth}");
+
+            var pixelDensityPPI = Math.Sqrt(Math.Pow(screenWidth, 2) + Math.Pow(screenHeight, 2)) / diagonalSizeInInches;
+
+            lblPPI.Text = $"Current Monitor's PPI: {pixelDensityPPI}";
+            Console.WriteLine($"Horizontal Inches = {horizontalSizeInInches}. Vertical Inches = {verticalSizeInInches}. Diagonal Inches = {diagonalSizeInInches}. Pixel Density (PPI) = {pixelDensityPPI}");
         }
     }
 }

--- a/Pixel Density/FormIntro.cs
+++ b/Pixel Density/FormIntro.cs
@@ -14,8 +14,8 @@ namespace Pixel_Density
         [DllImport("gdi32.dll")]
         static extern IntPtr CreateDC(string lpszDriver, string lpszDevice, string lpszOutput, IntPtr lpInitData);
 
-        private int _previousScreenIndex;
-        private int _currentScreenIndex;
+        private int? _previousScreenIndex;
+        private int? _currentScreenIndex;
 
         private bool ScreenChanged()
         {
@@ -44,26 +44,23 @@ namespace Pixel_Density
 
         public void SystemEvents_DisplaySettingsChanged(object sender, EventArgs e)
         {
-            CalculatePPI();
+            DisplayMonitorInfo(null, null);
         }
 
         private void FormIntro_Load(object sender, EventArgs e)
         {
             this.Location = new Point(0, 0);
             SystemEvents.DisplaySettingsChanged += new EventHandler(SystemEvents_DisplaySettingsChanged);
-            CalculatePPI();
+            DisplayMonitorInfo(null, null);
         }
 
-        private void FormIntro_Move(object sender, EventArgs e)
+        private void DisplayMonitorInfo(object sender, EventArgs e)
         {
-            if (ScreenChanged())
+            if (!ScreenChanged())
             {
-                CalculatePPI();
+                return;
             }
-        }
 
-        private void CalculatePPI()
-        {
             const int HORZSIZE = 4;
             const int VERTSIZE = 6;
             const double MM_TO_INCH_CONVERSION_FACTOR = 25.4;

--- a/Pixel Density/FormIntro.resx
+++ b/Pixel Density/FormIntro.resx
@@ -126,7 +126,7 @@ If you more or less see a gray screen, then your monitor's resolution has a pixe
 
 If you can discern the difference in the black/white squares, then you are able to see at the pixel level and may want to consider increasing your monitor's resolution. Note that even if you do see the individual pixels, images on screen are typically moving, yet this grid is still. Therefore, it may still be sufficient regardless.
 
-Upon clicking the button, a new form will appear and draw the grid.
+Upon clicking the button, a new fullscreen form will appear and draw the grid on the same screen that this window is on.
 
 Sit upright at your normal viewing distance from your monitor and click the button below to begin!</value>
   </data>

--- a/Pixel Density/FormIntro.resx
+++ b/Pixel Density/FormIntro.resx
@@ -117,7 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="label1.Text" xml:space="preserve">
+  <data name="lblIntro.Text" xml:space="preserve">
     <value>This application is meant to determine if your current monitor's pixel density/resolution is appropriate for your regular viewing distance.
 
 Black and white squares will be drawn in an alternating fashion. These squares will be exactly 1x1 pixel.


### PR DESCRIPTION
- Start density window maximized.
- Fix issue with the copy/paste from screenshot always taking primary monitor instead of actual window.
- Add current monitor data display to intro form.
- Draw density form on same screen that intro window is on when button is clicked.
- Add in GroupBox to display current monitor information.