### PR TITLE
Optimize pixel grid drawing

### DIFF
--- a/Pixel Density/FormDensity.Designer.cs
+++ b/Pixel Density/FormDensity.Designer.cs
@@ -41,7 +41,7 @@
             this.StartPosition = System.Windows.Forms.FormStartPosition.Manual;
             this.Text = "Pixel Density";
             this.Load += new System.EventHandler(this.FormDensity_Load);
-            this.Paint += new System.Windows.Forms.PaintEventHandler(this.Panel_Paint);
+            this.Paint += new System.Windows.Forms.PaintEventHandler(this.FormDensity_Paint);
             this.ResumeLayout(false);
 
         }

--- a/Pixel Density/FormDensity.cs
+++ b/Pixel Density/FormDensity.cs
@@ -19,7 +19,7 @@ namespace Pixel_Density
             this.WindowState = FormWindowState.Maximized;
         }
 
-        private void Panel_Paint(object sender, PaintEventArgs e)
+        private void FormDensity_Paint(object sender, PaintEventArgs e)
         {
             using (var blackPen = new Pen(Color.FromArgb(255, 0, 0, 0)))
             using (var whitePen = new Pen(Color.FromArgb(255, 255, 255, 255)))
@@ -42,18 +42,15 @@ namespace Pixel_Density
 
             Rectangle screenRectangle = RectangleToScreen(this.ClientRectangle);
 
-            var leftSide = 0;
-            var columnCounter = 0;
+            var leftSide = DRAWN_SQUARE_SIZE;
             var rowCounter = 0;
             var rowsRequired = this.Height / DRAWN_SQUARE_SIZE;
 
             while (leftSide <= this.Width)
             {
-                e.Graphics.CopyFromScreen(screenRectangle.Left, screenRectangle.Top, DRAWN_SQUARE_SIZE * columnCounter, 0, new Size(DRAWN_SQUARE_SIZE, DRAWN_SQUARE_SIZE));
-                leftSide += DRAWN_SQUARE_SIZE;
-                columnCounter++;
+                e.Graphics.CopyFromScreen(screenRectangle.Left, screenRectangle.Top, leftSide, 0, new Size(leftSide, DRAWN_SQUARE_SIZE));
+                leftSide *= 2;
             }
-
             while (rowCounter <= rowsRequired)
             {
                 rowCounter++;

--- a/Pixel Density/FormDensity.cs
+++ b/Pixel Density/FormDensity.cs
@@ -47,17 +47,17 @@ namespace Pixel_Density
             var rowCounter = 0;
             var rowsRequired = this.Height / DRAWN_SQUARE_SIZE;
 
-            while (leftSide <= this.Width && rowCounter <= rowsRequired)
+            while (leftSide <= this.Width)
             {
-                e.Graphics.CopyFromScreen(screenRectangle.Left, screenRectangle.Top, DRAWN_SQUARE_SIZE * columnCounter, DRAWN_SQUARE_SIZE * rowCounter, new Size(DRAWN_SQUARE_SIZE, DRAWN_SQUARE_SIZE));
+                e.Graphics.CopyFromScreen(screenRectangle.Left, screenRectangle.Top, DRAWN_SQUARE_SIZE * columnCounter, 0, new Size(DRAWN_SQUARE_SIZE, DRAWN_SQUARE_SIZE));
                 leftSide += DRAWN_SQUARE_SIZE;
                 columnCounter++;
-                if (leftSide >= this.Width)
-                {
-                    rowCounter++;
-                    columnCounter = 0;
-                    leftSide = 0;
-                }
+            }
+
+            while (rowCounter <= rowsRequired)
+            {
+                rowCounter++;
+                e.Graphics.CopyFromScreen(screenRectangle.Left, screenRectangle.Top, 0, DRAWN_SQUARE_SIZE * rowCounter, new Size(this.Width, DRAWN_SQUARE_SIZE));
             }
         }
     }


### PR DESCRIPTION
Optimize pixel grid drawing by replicating the first row exponentially across column.
After first row is drawn, copy/paste that row for all other rows (non-exponentially)